### PR TITLE
Heisenberg now uses direct_nosym

### DIFF
--- a/tutorial/Heisenberg2spin.py
+++ b/tutorial/Heisenberg2spin.py
@@ -52,7 +52,8 @@ if(verbose):
     print("\n1. Constrained solution \n - nelecs = ",nelecs[0]);
 
 # h2e terms for 2,0 case
-h2e_20[0,0,1,1] = 2*J/4; # 2 undoes 1/2 out front
+h2e_20[0,0,1,1] = J/4;
+h2e_20[1,1,0,0] = J/4;
 
 # solve with FCISolver object
 cisolver20 = fci.direct_nosym.FCI();
@@ -63,7 +64,8 @@ if(verbose):
     print("FCI energies = ", E_20);
     
 # h2e terms for 0,2 case
-h2e_02[0,0,1,1] = 2*J/4; # 2 undoes 1/2 out front
+h2e_02[0,0,1,1] = J/4;
+h2e_02[1,1,0,0] = J/4;
 
 # solve
 cisolver02 = fci.direct_nosym.FCI();
@@ -102,8 +104,8 @@ nelecs_hub = 1,1;
 # all terms are 2e terms
 h2e_hub[0,0,1,1] = -J/4;
 h2e_hub[1,1,0,0] = -J/4;
-h2e_hub[0,1,1,0] = -J/2;
-h2e_hub[1,0,0,1] = -J/2;
+h2e_hub[0,1,1,0] = J/2;
+h2e_hub[1,0,0,1] = J/2;
 h2e_hub[0,0,0,0] = J/4; # mapping means this term is hubbard like
 h2e_hub[1,1,1,1] = J/4;
 

--- a/tutorial/Heisenberg2spin.py
+++ b/tutorial/Heisenberg2spin.py
@@ -11,9 +11,10 @@ Specific case:
 Solve 2 spin heisenberg hamiltonian
 
 Formalism:
-h1e = (p|h|q) p,q spatial orbitals
-h2e = (pq|h|rs) chemists notation, <pr|h|qs> physicists notation
+- h1e = (p|h|q) p,q spatial orbitals
+- h2e = (pq|h|rs) chemists notation, <pr|h|qs> physicists notation
         thus hermicity means h_pqrs = h_qpsr
+- as result of identity E_pq,rs = E_rs,pq, h_pq_rs = h_rs_pq
 '''
 
 import numpy as np

--- a/tutorial/Heisenberg2spin.py
+++ b/tutorial/Heisenberg2spin.py
@@ -50,20 +50,20 @@ if(verbose):
 h2e_20[0,0,1,1] = 2*J/4; # 2 undoes 1/2 out front
 
 # solve with FCISolver object
-cisolver = fci.direct_spin1.FCI()
-cisolver.max_cycle = 100
-cisolver.conv_tol = 1e-8
-E_20, v_20 = cisolver.kernel(h1e, h2e_20, norbs, nelecs[0],nroots=4);
+cisolver20 = fci.direct_nosym.FCI();
+cisolver20.max_cycle = 100
+cisolver20.conv_tol = 1e-8
+E_20, v_20 = cisolver20.kernel(h1e, h2e_20, norbs, nelecs[0],nroots=4);
 if(verbose):
     print("FCI energies = ", E_20);
     
 # h2e terms for 0,2 case
 h2e_02[0,0,1,1] = 2*J/4; # 2 undoes 1/2 out front
 
-# solve with FCISolver object
-cisolver = fci.direct_spin1.FCI()
-cisolver.max_cycle = 100
-cisolver.conv_tol = 1e-8
+# solve
+cisolver02 = fci.direct_nosym.FCI();
+cisolver02.max_cycle = 100
+cisolver02.conv_tol = 1e-8
 E_02, v_02 = cisolver.kernel(h1e, h2e_02, norbs, nelecs[2],nroots=4);
 if(verbose):
     print("\n - nelecs = ",nelecs[2]);
@@ -80,32 +80,36 @@ if(verbose):
 
 #### map solution onto Hubbard model
 
+# init h1e, h2e
+h1e_hub = np.zeros((norbs, norbs));
+h2e_hub = np.zeros((norbs, norbs,norbs,norbs)); # for nelecs = 1,1
+
 # hubbard inputs
 nelecs_hub = 1,1;
 
 # all terms are 2e terms
-h2e[0,0,1,1] = -J/4;
-h2e[1,1,0,0] = -J/4;
-h2e[0,1,1,0] = -J/2;
-h2e[1,0,0,1] = -J/2;
-h2e[0,0,0,0] = J/4; # mapping means this term is hubbard like
-h2e[1,1,1,1] = J/4;
+h2e_hub[0,0,1,1] = -J/4;
+h2e_hub[1,1,0,0] = -J/4;
+h2e_hub[0,1,1,0] = -J/2;
+h2e_hub[1,0,0,1] = -J/2;
+h2e_hub[0,0,0,0] = J/4; # mapping means this term is hubbard like
+h2e_hub[1,1,1,1] = J/4;
 
-E_map, v_map = cisolver.kernel(h1e, h2e, norbs, nelecs_hub,nroots=4);
+E_map, v_map = cisolver.kernel(h1e_hub, h2e_hub, norbs, nelecs_hub,nroots=4);
 if(verbose):
     print("\n2. Mapped solution, nelecs = ",nelecs_hub);
     print("FCI energies = ", E_map);
     #print(v_map);
     
-
+'''
 #### solve with direct_uhf method, still constrained basis
 
 # need to reconfigure h arrays
 
 # 1e part
 # UHF takes h1e = (h1e alpha, h1e beta)
-h1e_alpha = h1e;
-h1e_beta = h1e; # still just empty
+h1e_alpha = np.zeros((norbs, norbs));
+h1e_beta = np.zeros((norbs, norbs)); # still just empty
 
 # 2e part
 # UHF takes h2e = h2e alpha-alpha, h2e alpha-beta, h2e beta-beta
@@ -130,4 +134,6 @@ E_uhf, v_uhf = cisolver.kernel((h1e_alpha, h1e_beta), (h2e_alpha_alpha, h2e_alph
 if(verbose):
     print("\n3. UHF solution, constrained basis, nelecs = ",nelecs_hub);
     print("UHF energies = ", E_uhf);
+    
+'''
 

--- a/tutorial/Heisenberg2spin.py
+++ b/tutorial/Heisenberg2spin.py
@@ -75,11 +75,10 @@ if(verbose):
     print("FCI energies = ", E_02);
     
 # h2e terms for 1,1 case
-if True:
-    h2e_11[0,0,1,1] = -J/4
-    h2e_11[1,1,0,0] = -J/4;
-    h2e_11[1,0,0,1] = J/2;
-    h2e_11[0,1,1,0] = J/2;
+h2e_11[0,0,1,1] = -J/4
+h2e_11[1,1,0,0] = -J/4;
+h2e_11[1,0,0,1] = J/2;
+h2e_11[0,1,1,0] = J/2;
     
 # solve
 cisolver11 = fci.direct_nosym.FCI();


### PR DESCRIPTION
I showed h_pqrs = h_rspq generally. This is the basic assumption of direct_nosym and the only one needed for the heisenberg model. This identity allowed me to resolve the factors of 1/2 I was off by everywhere and get heisenberg working in a way I understand